### PR TITLE
Handle case of empty field defined by a behaviour schema.

### DIFF
--- a/Products/CMFDiffTool/BaseDiff.py
+++ b/Products/CMFDiffTool/BaseDiff.py
@@ -13,6 +13,8 @@ from App.class_init import InitializeClass
 from Products.CMFDiffTool.interfaces import IDifference
 from Products.CMFDiffTool import CMFDiffToolMessageFactory as _
 
+from plone.dexterity.interfaces import IDexterityContent
+
 
 class BaseDiff:
     """Basic diff type"""
@@ -70,7 +72,11 @@ def _getValue(ob, field, field_name, convert_to_str=True):
     # Check for the attribute without acquisition.  If it's there,
     # grab it *with* acquisition, so things like ComputedAttribute
     # will work
-    if field and hasattr(aq_base(ob), field):
+    if field_name and hasattr(aq_base(ob), field_name):
+        value = getattr(ob, field_name)
+    elif IDexterityContent.providedBy(ob):
+        return field.default
+    elif field and hasattr(aq_base(ob), field):
         value = getattr(ob, field)
     elif hasattr(aq_base(ob), 'getField'):
         # Archetypes with an adapter extended schema needs special handling

--- a/Products/CMFDiffTool/dexteritydiff.py
+++ b/Products/CMFDiffTool/dexteritydiff.py
@@ -119,7 +119,7 @@ class DexterityCompoundDiff(object):
         return diff_type(
             obj1,
             obj2,
-            field.getName(),
+            field,
             id1=self.id1,
             id2=self.id2,
             field_name=field.getName(),


### PR DESCRIPTION
In case of empty value (== the field attribute doesnt exist yet), return the field default value rather than trying to acces the field attribute.
