### PR TITLE
add inline_diff for FieldDiff

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add generic `inline_diff` implementation for FieldDiff.
+  [davisagli]
 
 
 2.1.2 (2015-09-28)

--- a/Products/CMFDiffTool/FieldDiff.py
+++ b/Products/CMFDiffTool/FieldDiff.py
@@ -1,12 +1,20 @@
 # -*- coding: utf-8 -*-
 import difflib
 from App.class_init import InitializeClass
+from os import linesep
 from Products.CMFDiffTool.BaseDiff import BaseDiff, _getValue
+
 
 class FieldDiff(BaseDiff):
     """Text difference"""
 
     meta_type = "Field Diff"
+
+    same_fmt = """<div class="%s">%s</div>"""
+    inlinediff_fmt = """<div class="%s">
+    <div class="diff_sub">%s</div>
+    <div class="diff_add">%s</div>
+</div>"""
 
     def _parseField(self, value, filename=None):
         """Parse a field value in preparation for diffing"""
@@ -55,6 +63,33 @@ class FieldDiff(BaseDiff):
             else:
                 raise ValueError, 'unknown tag ' + `tag`
         return '\n'.join(r)
+
+    def inline_diff(self):
+        css_class = 'InlineDiff'
+        inlinediff_fmt = self.inlinediff_fmt
+        same_fmt = self.same_fmt
+        r=[]
+        a = self._parseField(self.oldValue, filename=self.oldFilename)
+        b = self._parseField(self.newValue, filename=self.newFilename)
+        for tag, alo, ahi, blo, bhi in self.getLineDiffs():
+            if tag == 'replace':
+                for i in xrange(alo, ahi):
+                    r.append(inlinediff_fmt % (css_class, a[i], ''))
+                for i in xrange(blo, bhi):
+                    r.append(inlinediff_fmt % (css_class, '', b[i]))
+            elif tag == 'delete':
+                for i in xrange(alo, ahi):
+                    r.append(inlinediff_fmt % (css_class, a[i], ''))
+            elif tag == 'insert':
+                for i in xrange(blo, bhi):
+                    r.append(inlinediff_fmt % (css_class, '', b[i]))
+            elif tag == 'equal':
+                for i in xrange(alo, ahi):
+                    r.append(same_fmt % (css_class, a[i]))
+            else:
+                raise ValueError('unknown tag ' + `tag`)
+        return '\n'.join(r)
+
 
 InitializeClass(FieldDiff)
 

--- a/Products/CMFDiffTool/tests/testListDiff.py
+++ b/Products/CMFDiffTool/tests/testListDiff.py
@@ -66,7 +66,18 @@ class TestListDiff(ZopeTestCase.ZopeTestCase):
         diff = ListDiff(a, b, 'attribute')
         self.assertEqual(diff.ndiff(), expected)
 
-        # FIXME: need tests for other kinds of diffs
+    def test_inline_diff(self):
+        a = A()
+        b = B()
+        expected = """<div class="InlineDiff">1</div>
+<div class="InlineDiff">2</div>
+<div class="InlineDiff">3</div>
+<div class="InlineDiff">
+    <div class="diff_sub"></div>
+    <div class="diff_add">4</div>
+</div>"""
+        diff = ListDiff(a, b, 'attribute')
+        self.assertEqual(diff.inline_diff(), expected)
 
 
 def test_suite():
@@ -74,4 +85,3 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestListDiff))
     return suite
-


### PR DESCRIPTION
This adds inline diff support for any subclass of FieldDiff that implements `_parseField`.

This PR is for Plone 4.3 (CMFDiffTool 2.1.x)