### PR TITLE
add inline_diff for FieldDiff

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Incompatibilities:
 
 New:
 
-- *add item here*
+- Add generic `inline_diff` implementation for FieldDiff.
+  [davisagli]
 
 Fixes:
 

--- a/Products/CMFDiffTool/FieldDiff.py
+++ b/Products/CMFDiffTool/FieldDiff.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from App.class_init import InitializeClass
+from os import linesep
 from Products.CMFDiffTool.BaseDiff import _getValue
 from Products.CMFDiffTool.BaseDiff import BaseDiff
 
@@ -10,6 +11,12 @@ class FieldDiff(BaseDiff):
     """Text difference"""
 
     meta_type = 'Field Diff'
+
+    same_fmt = """<div class="%s">%s</div>"""
+    inlinediff_fmt = """<div class="%s">
+    <div class="diff_sub">%s</div>
+    <div class="diff_add">%s</div>
+</div>"""
 
     def _parseField(self, value, filename=None):
         """Parse a field value in preparation for diffing"""
@@ -62,6 +69,33 @@ class FieldDiff(BaseDiff):
             else:
                 raise ValueError('unknown tag %r', tag)
         return '\n'.join(r)
+
+    def inline_diff(self):
+        css_class = 'InlineDiff'
+        inlinediff_fmt = self.inlinediff_fmt
+        same_fmt = self.same_fmt
+        r=[]
+        a = self._parseField(self.oldValue, filename=self.oldFilename)
+        b = self._parseField(self.newValue, filename=self.newFilename)
+        for tag, alo, ahi, blo, bhi in self.getLineDiffs():
+            if tag == 'replace':
+                for i in xrange(alo, ahi):
+                    r.append(inlinediff_fmt % (css_class, a[i], ''))
+                for i in xrange(blo, bhi):
+                    r.append(inlinediff_fmt % (css_class, '', b[i]))
+            elif tag == 'delete':
+                for i in xrange(alo, ahi):
+                    r.append(inlinediff_fmt % (css_class, a[i], ''))
+            elif tag == 'insert':
+                for i in xrange(blo, bhi):
+                    r.append(inlinediff_fmt % (css_class, '', b[i]))
+            elif tag == 'equal':
+                for i in xrange(alo, ahi):
+                    r.append(same_fmt % (css_class, a[i]))
+            else:
+                raise ValueError('unknown tag ' + `tag`)
+        return '\n'.join(r)
+
 
 InitializeClass(FieldDiff)
 

--- a/Products/CMFDiffTool/tests/testListDiff.py
+++ b/Products/CMFDiffTool/tests/testListDiff.py
@@ -73,4 +73,15 @@ class TestListDiff(TestCase):
         diff = ListDiff(a, b, 'attribute')
         self.assertEqual(diff.ndiff(), expected)
 
-        # FIXME: need tests for other kinds of diffs
+    def test_inline_diff(self):
+        a = A()
+        b = B()
+        expected = """<div class="InlineDiff">1</div>
+<div class="InlineDiff">2</div>
+<div class="InlineDiff">3</div>
+<div class="InlineDiff">
+    <div class="diff_sub"></div>
+    <div class="diff_add">4</div>
+</div>"""
+        diff = ListDiff(a, b, 'attribute')
+        self.assertEqual(diff.inline_diff(), expected)


### PR DESCRIPTION
This adds inline diff support for any subclass of FieldDiff that implements `_parseField`.

This PR is for Plone 5 (CMFDiffTool master)