### PR TITLE
Fix problem with changes to set objects

### DIFF
--- a/Products/CMFDiffTool/ListDiff.py
+++ b/Products/CMFDiffTool/ListDiff.py
@@ -11,6 +11,10 @@ class ListDiff(FieldDiff):
     def _parseField(self, value, filename=None):
         """Parse a field value in preparation for diffing"""
         # Return the list as is for diffing
-        return value
+        if type(value) is set:
+            # A set cannot be indexed, so return a list of a set
+            return list(value)
+        else:
+            return value
 
 InitializeClass(ListDiff)


### PR DESCRIPTION
Dexterity types that use selectable elements (zope.schema.Set) have objects of type "set". When using CMFDiff tool to examine changes between versions having differences between these set objects, FieldDiff.inline_diff() fails as it assumes the objects a and b can be indexed. This is solved by passing a list of the object, if the object is of type "set".