### PR TITLE
Generate a diff using the referenced objects instead of the reference object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- When field is a Relation List, get the referenced objects instead of diffing
+  on the actual reference objects.
+  [frapell]
 
 Bug fixes:
 

--- a/Products/CMFDiffTool/BaseDiff.py
+++ b/Products/CMFDiffTool/BaseDiff.py
@@ -10,6 +10,7 @@ from plone.dexterity.interfaces import IDexterityContent
 from Products.CMFDiffTool import CMFDiffToolMessageFactory as _
 from Products.CMFDiffTool.interfaces import IDifference
 from Products.CMFPlone.utils import safe_hasattr
+from z3c.relationfield.relation import RelationValue
 from zope.i18n import translate
 from zope.interface import implementer
 
@@ -89,6 +90,27 @@ def _getValue(ob, field, field_name, convert_to_str=True):
         value = value()
     except (AttributeError, TypeError):
         pass
+
+    new_value = value
+    if isinstance(value, list) or isinstance(value, tuple):
+        new_value = list()
+        for val in value:
+            if isinstance(val, RelationValue):
+                try:
+                    obj = val.to_object
+                except:
+                    obj = None
+                new_value.append(obj)
+        if isinstance(value, tuple):
+            new_value = tuple(new_value)
+    value = new_value
+
+    if isinstance(value, RelationValue):
+        try:
+            obj = value.to_object
+        except:
+            obj = None
+        value = obj
 
     if convert_to_str:
         # If this is some object, convert it to a string

--- a/Products/CMFDiffTool/BaseDiff.py
+++ b/Products/CMFDiffTool/BaseDiff.py
@@ -101,6 +101,8 @@ def _getValue(ob, field, field_name, convert_to_str=True):
                 except:
                     obj = None
                 new_value.append(obj)
+            else:
+                new_value.append(val)
         if isinstance(value, tuple):
             new_value = tuple(new_value)
     value = new_value

--- a/Products/CMFDiffTool/ListDiff.py
+++ b/Products/CMFDiffTool/ListDiff.py
@@ -24,8 +24,7 @@ class RelationListDiff(FieldDiff):
 
     same_fmt = """<div class="%s"><a target="_blank" href="%s">%s</a></div>"""
     inlinediff_fmt = """<div class="%s">
-        <div class="diff_sub"><a target="_blank" href="%s">%s</a></div>
-        <div class="diff_add"><a target="_blank" href="%s">%s</a></div>
+        <div class="%s"><a target="_blank" href="%s">%s</a></div>
     </div>"""
 
     def _parseField(self, value, filename=None):
@@ -52,24 +51,24 @@ class RelationListDiff(FieldDiff):
                     obj = self.oldValue[i]
                     obj_title = obj.Title()
                     obj_url = obj.absolute_url()
-                    r.append(inlinediff_fmt % (css_class, obj_url, obj_title, '', ''))
+                    r.append(inlinediff_fmt % (css_class, "diff_sub", obj_url, obj_title))
                 for i in xrange(blo, bhi):
                     obj = self.newValue[i]
                     obj_title = obj.Title()
                     obj_url = obj.absolute_url()
-                    r.append(inlinediff_fmt % (css_class, '', '', obj_url, obj_title))
+                    r.append(inlinediff_fmt % (css_class, "diff_add", obj_url, obj_title))
             elif tag == 'delete':
                 for i in xrange(alo, ahi):
                     obj = self.oldValue[i]
                     obj_title = obj.Title()
                     obj_url = obj.absolute_url()
-                    r.append(inlinediff_fmt % (css_class, obj_url, obj_title, '', ''))
+                    r.append(inlinediff_fmt % (css_class, "diff_sub", obj_url, obj_title))
             elif tag == 'insert':
                 for i in xrange(blo, bhi):
                     obj = self.newValue[i]
                     obj_title = obj.Title()
                     obj_url = obj.absolute_url()
-                    r.append(inlinediff_fmt % (css_class, '', '', obj_url, obj_title))
+                    r.append(inlinediff_fmt % (css_class, "diff_add", obj_url, obj_title))
             elif tag == 'equal':
                 for i in xrange(alo, ahi):
                     obj = self.oldValue[i]

--- a/Products/CMFDiffTool/ListDiff.py
+++ b/Products/CMFDiffTool/ListDiff.py
@@ -17,4 +17,101 @@ class ListDiff(FieldDiff):
         else:
             return value
 
+
+class RelationListDiff(FieldDiff):
+
+    meta_type = 'Related List Diff'
+
+    same_fmt = """<div class="%s"><a target="_blank" href="%s">%s</a></div>"""
+    inlinediff_fmt = """<div class="%s">
+        <div class="diff_sub"><a target="_blank" href="%s">%s</a></div>
+        <div class="diff_add"><a target="_blank" href="%s">%s</a></div>
+    </div>"""
+
+    def _parseField(self, value, filename=None):
+        """Take RelationValues and just return the target UID so we can compare"""
+
+        if filename is None:
+            # Since we only want to compare a single field, make a
+            # one-item list out of it
+            return ['/'.join(val.getPhysicalPath()) for val in value]
+        else:
+            return [
+                self.filenameTitle(filename),
+                ['/'.join(val.getPhysicalPath()) for val in value]
+            ]
+
+    def inline_diff(self):
+        css_class = 'InlineDiff'
+        inlinediff_fmt = self.inlinediff_fmt
+        same_fmt = self.same_fmt
+        r=[]
+        for tag, alo, ahi, blo, bhi in self.getLineDiffs():
+            if tag == 'replace':
+                for i in xrange(alo, ahi):
+                    obj = self.oldValue[i]
+                    obj_title = obj.Title()
+                    obj_url = obj.absolute_url()
+                    r.append(inlinediff_fmt % (css_class, obj_url, obj_title, '', ''))
+                for i in xrange(blo, bhi):
+                    obj = self.newValue[i]
+                    obj_title = obj.Title()
+                    obj_url = obj.absolute_url()
+                    r.append(inlinediff_fmt % (css_class, '', '', obj_url, obj_title))
+            elif tag == 'delete':
+                for i in xrange(alo, ahi):
+                    obj = self.oldValue[i]
+                    obj_title = obj.Title()
+                    obj_url = obj.absolute_url()
+                    r.append(inlinediff_fmt % (css_class, obj_url, obj_title, '', ''))
+            elif tag == 'insert':
+                for i in xrange(blo, bhi):
+                    obj = self.newValue[i]
+                    obj_title = obj.Title()
+                    obj_url = obj.absolute_url()
+                    r.append(inlinediff_fmt % (css_class, '', '', obj_url, obj_title))
+            elif tag == 'equal':
+                for i in xrange(alo, ahi):
+                    obj = self.oldValue[i]
+                    obj_title = obj.Title()
+                    obj_url = obj.absolute_url()
+                    r.append(same_fmt % (css_class, obj_url, obj_title))
+            else:
+                raise ValueError('unknown tag ' + `tag`)
+        return '\n'.join(r)
+
+    def ndiff(self):
+        """Return a textual diff"""
+        r = []
+        for tag, alo, ahi, blo, bhi in self.getLineDiffs():
+            if tag == 'replace':
+                for i in xrange(alo, ahi):
+                    obj = self.oldValue[i]
+                    obj_url = obj.absolute_url()
+                    r.append("- %s" % obj_url)
+                for i in xrange(blo, bhi):
+                    obj = self.newValue[i]
+                    obj_url = obj.absolute_url()
+                    r.append("+ %s" % obj_url)
+            elif tag == 'delete':
+                for i in xrange(alo, ahi):
+                    obj = self.oldValue[i]
+                    obj_url = obj.absolute_url()
+                    r.append("- %s" % obj_url)
+            elif tag == 'insert':
+                for i in xrange(blo, bhi):
+                    obj = self.newValue[i]
+                    obj_url = obj.absolute_url()
+                    r.append("+ %s" % obj_url)
+            elif tag == 'equal':
+                for i in xrange(alo, ahi):
+                    obj = self.oldValue[i]
+                    obj_url = obj.absolute_url()
+                    r.append("  %s" % obj_url)
+            else:
+                raise ValueError('unknown tag %r', tag)
+        return '\n'.join(r)
+
+
 InitializeClass(ListDiff)
+InitializeClass(RelationListDiff)

--- a/Products/CMFDiffTool/dexteritydiff.py
+++ b/Products/CMFDiffTool/dexteritydiff.py
@@ -5,11 +5,13 @@ from Products.CMFDiffTool.choicediff import ChoiceDiff
 from Products.CMFDiffTool.CMFDTHtmlDiff import CMFDTHtmlDiff
 from Products.CMFDiffTool.FieldDiff import FieldDiff
 from Products.CMFDiffTool.ListDiff import ListDiff
+from Products.CMFDiffTool.ListDiff import RelationListDiff
 from Products.CMFDiffTool.namedfile import FILE_FIELD_TYPES
 from Products.CMFDiffTool.namedfile import NamedFileBinaryDiff
 from Products.CMFDiffTool.namedfile import NamedFileListDiff
 from Products.CMFDiffTool.TextDiff import AsTextDiff
 from Products.CMFDiffTool.TextDiff import TextDiff
+from z3c.relationfield.schema import RelationList
 from zope.globalrequest import getRequest
 from zope.schema import Bool
 from zope.schema import Bytes
@@ -26,6 +28,7 @@ from zope.schema import Time
 # adaptation, in order to provide better extensibility.
 FIELDS_AND_DIFF_TYPES_RELATION = [
     (FILE_FIELD_TYPES, NamedFileBinaryDiff),
+    ((RelationList,), RelationListDiff),
     ((Iterable, Container), ListDiff),
     ((Date, Datetime, Time), AsTextDiff),
     ((Bool, ), AsTextDiff),

--- a/Products/CMFDiffTool/testing.py
+++ b/Products/CMFDiffTool/testing.py
@@ -51,7 +51,7 @@ class DXLayer(PloneSandboxLayer):
             behaviors=(
                 'plone.app.versioningbehavior.behaviors.IVersionable',
                 'plone.app.dexterity.behaviors.metadata.IBasic',
-                'plone.app.dexterity.behaviors.metadata.IRelatedItems',
+                'plone.app.relationfield.behavior.IRelatedItems',
                 'plone.app.contenttypes.behaviors.collection.ICollection',
             ),
             model_source='''


### PR DESCRIPTION
A diff on a RelationList looked like this:

![spectacle b12124](https://cloud.githubusercontent.com/assets/851006/23143071/1773c9d2-f79e-11e6-9840-a1bc5810849d.png)

With this fix, it looks like this:

![spectacle c31661](https://cloud.githubusercontent.com/assets/851006/23143228/eb2f1ef2-f79e-11e6-8ba7-d7efab15432e.png)
