### PR TITLE
Fixed AttributeError: 'NoneType' 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed AttributeError: 'NoneType' if the object doesn't have the expected attribute [rristow]
 
 
 3.1.3 (2016-09-09)

--- a/Products/CMFDiffTool/FieldDiff.py
+++ b/Products/CMFDiffTool/FieldDiff.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from App.class_init import InitializeClass
-from os import linesep
 from Products.CMFDiffTool.BaseDiff import _getValue
 from Products.CMFDiffTool.BaseDiff import BaseDiff
 
@@ -74,7 +73,7 @@ class FieldDiff(BaseDiff):
         css_class = 'InlineDiff'
         inlinediff_fmt = self.inlinediff_fmt
         same_fmt = self.same_fmt
-        r=[]
+        r = []
         a = self._parseField(self.oldValue, filename=self.oldFilename)
         b = self._parseField(self.newValue, filename=self.newFilename)
         for tag, alo, ahi, blo, bhi in self.getLineDiffs():
@@ -93,7 +92,7 @@ class FieldDiff(BaseDiff):
                 for i in xrange(alo, ahi):
                     r.append(same_fmt % (css_class, a[i]))
             else:
-                raise ValueError('unknown tag ' + `tag`)
+                raise ValueError('unknown tag "%s"' % tag)
         return '\n'.join(r)
 
 

--- a/Products/CMFDiffTool/ListDiff.py
+++ b/Products/CMFDiffTool/ListDiff.py
@@ -10,12 +10,13 @@ class ListDiff(FieldDiff):
 
     def _parseField(self, value, filename=None):
         """Parse a field value in preparation for diffing"""
-        # Return the list as is for diffing
-        if type(value) is set:
-            # A set cannot be indexed, so return a list of a set
-            return list(value)
-        else:
+        if type(value) is list or type(value) is tuple:
             return value
+        else:
+            if type(value) is set:
+                return list(value)
+            else:
+                return [value]
 
 
 class RelationListDiff(FieldDiff):
@@ -44,7 +45,7 @@ class RelationListDiff(FieldDiff):
         css_class = 'InlineDiff'
         inlinediff_fmt = self.inlinediff_fmt
         same_fmt = self.same_fmt
-        r=[]
+        r = []
         for tag, alo, ahi, blo, bhi in self.getLineDiffs():
             if tag == 'replace':
                 for i in xrange(alo, ahi):
@@ -76,7 +77,7 @@ class RelationListDiff(FieldDiff):
                     obj_url = obj.absolute_url()
                     r.append(same_fmt % (css_class, obj_url, obj_title))
             else:
-                raise ValueError('unknown tag ' + `tag`)
+                raise ValueError('unknown tag %s' % tag)
         return '\n'.join(r)
 
     def ndiff(self):

--- a/Products/CMFDiffTool/dexteritydiff.py
+++ b/Products/CMFDiffTool/dexteritydiff.py
@@ -179,4 +179,3 @@ class DexterityCompoundDiff(object):
                 all_fields += [(group.fields[name].field, name) for name in group.fields]
 
         return all_fields
-

--- a/Products/CMFDiffTool/interfaces/portal_diff.py
+++ b/Products/CMFDiffTool/interfaces/portal_diff.py
@@ -2,5 +2,5 @@
 # Copyright (c) 2003 The Connexions Project, All Rights Reserved
 # Written by Brent Hendricks
 
-from Products.CMFDiffTool.interfaces import IDifference  # NOQA
 from Products.CMFDiffTool.interfaces import IDiffTool as portal_diff  # NOQA
+from Products.CMFDiffTool.interfaces import IDifference  # NOQA

--- a/Products/CMFDiffTool/tests/testChangeSet.py
+++ b/Products/CMFDiffTool/tests/testChangeSet.py
@@ -5,11 +5,11 @@
 from Acquisition import aq_base
 from os import linesep
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FUNCTIONAL_TESTING  # NOQA
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from Products.CMFCore.utils import getToolByName
 from Products.CMFDiffTool.ChangeSet import BaseChangeSet
 from Products.CMFPlone.utils import safe_hasattr
-from plone.app.testing import setRoles
-from plone.app.testing import TEST_USER_ID
 from unittest import TestCase
 
 

--- a/Products/CMFDiffTool/tests/testListDiff.py
+++ b/Products/CMFDiffTool/tests/testListDiff.py
@@ -29,6 +29,24 @@ class TestListDiff(TestCase):
         from Products.CMFDiffTool.interfaces.portal_diff import IDifference
         self.assertTrue(IDifference.implementedBy(ListDiff))
 
+    def testInvalidValue(self):
+        """ Test if no error with invalid values """
+        a = A()
+        a.attribute = []
+        b = A()
+
+        b.attribute = None
+        diff = ListDiff(a, b, 'attribute')
+        self.assertEqual([('insert', 0, 0, 0, 1)], diff.getLineDiffs())
+
+        b.attribute = 0
+        diff = ListDiff(a, b, 'attribute')
+        self.assertEqual([('insert', 0, 0, 0, 1)], diff.getLineDiffs())
+
+        b.attribute = ""
+        diff = ListDiff(a, b, 'attribute')
+        self.assertEqual([('insert', 0, 0, 0, 1)], diff.getLineDiffs())
+
     def testAttributeSame(self):
         """Test attribute with same value"""
         a = A()


### PR DESCRIPTION
Fixed AttributeError: 'NoneType' if the object doesn't have the expected attribute.