### PR TITLE
When displaying differences on a zope.schema.List field, vocabulary terms titles are displayed (if a vocabulary is linked to the field)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.py[co]
 build
 dist
+include/
+lib/
 *.mo
 .installed.cfg
 bin/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Bug fixes:
 
 - Display titles in diff of zope.schema.List using vocabulary
   [sgeulette]
+- Flake8 corrections
+  [sgeulette]
 
 3.2.1 (2018-09-23)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,18 +4,10 @@ Changelog
 3.2.2 (unreleased)
 ------------------
 
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
-
 Bug fixes:
 
-- *add item here*
-
+- Display titles in diff of zope.schema.List using vocabulary
+  [sgeulette]
 
 3.2.1 (2018-09-23)
 ------------------

--- a/Products/CMFDiffTool/ATCompoundDiff.py
+++ b/Products/CMFDiffTool/ATCompoundDiff.py
@@ -126,4 +126,5 @@ class ATCompoundDiff:
                                        'schemata': schemata_name})
         return fields
 
+
 InitializeClass(ATCompoundDiff)

--- a/Products/CMFDiffTool/BaseDiff.py
+++ b/Products/CMFDiffTool/BaseDiff.py
@@ -4,8 +4,8 @@
    Calculate differences between content objects
 """
 
-from Acquisition import aq_base
 from AccessControl.class_init import InitializeClass
+from Acquisition import aq_base
 from plone.dexterity.interfaces import IDexterityContent
 from Products.CMFDiffTool import CMFDiffToolMessageFactory as _
 from Products.CMFDiffTool.interfaces import IDifference
@@ -63,7 +63,7 @@ class BaseDiff:
     def filenameTitle(self, filename):
         """Translate the filename leading text
         """
-        msg = _(u"Filename: ${filename}",
+        msg = _(u'Filename: ${filename}',
                 mapping={'filename': filename})
         return translate(msg)
 
@@ -73,8 +73,8 @@ def _getValue(ob, field, field_name, convert_to_str=True):
     # grab it *with* acquisition, so things like ComputedAttribute
     # will work
     if IDexterityContent.providedBy(ob) and field:
-        # we need a special handling for subjects because the field is stored as
-        # `subject` attribute but the schema name is `subjects`
+        # we need a special handling for subjects because the field is stored
+        # as `subject` attribute but the schema name is `subjects`
         # see plone.app.dexterity.behaviors.metadata.ICategorization and
         # plone.dexterity.content.DexterityContent
         if field == 'subjects':
@@ -105,7 +105,7 @@ def _getValue(ob, field, field_name, convert_to_str=True):
             if isinstance(val, RelationValue):
                 try:
                     obj = val.to_object
-                except:
+                except Exception:
                     obj = None
                 new_value.append(obj)
             else:
@@ -117,7 +117,7 @@ def _getValue(ob, field, field_name, convert_to_str=True):
     if isinstance(value, RelationValue):
         try:
             obj = value.to_object
-        except:
+        except Exception:
             obj = None
         value = obj
 
@@ -130,5 +130,6 @@ def _getValue(ob, field, field_name, convert_to_str=True):
             pass
 
     return value
+
 
 InitializeClass(BaseDiff)

--- a/Products/CMFDiffTool/BinaryDiff.py
+++ b/Products/CMFDiffTool/BinaryDiff.py
@@ -51,10 +51,11 @@ class BinaryDiff(FieldDiff):
             html.append(
                 self.inlinediff_fmt % (css_class,
                                        self.filenameTitle(self.oldFilename),
-                                       self.filenameTitle(self.newFilename))
+                                       self.filenameTitle(self.newFilename)),
             )
 
         if html:
             return linesep.join(html)
+
 
 InitializeClass(BinaryDiff)

--- a/Products/CMFDiffTool/CMFDTHtmlDiff.py
+++ b/Products/CMFDiffTool/CMFDTHtmlDiff.py
@@ -28,4 +28,5 @@ class CMFDTHtmlDiff(TextDiff):
             value = getattr(value, 'raw', value)
         return TextDiff._parseField(self, value, filename)
 
+
 InitializeClass(CMFDTHtmlDiff)

--- a/Products/CMFDiffTool/CMFDiffTool.py
+++ b/Products/CMFDiffTool/CMFDiffTool.py
@@ -4,8 +4,8 @@
    Calculate differences between content objects
 """
 from AccessControl import ClassSecurityInfo
-from Acquisition import aq_base
 from AccessControl.class_init import InitializeClass
+from Acquisition import aq_base
 from OFS.SimpleItem import SimpleItem
 from Products.CMFCore.permissions import ManagePortal
 from Products.CMFCore.utils import registerToolInterface
@@ -176,6 +176,7 @@ def unregisterDiffType(klass):
     interface."""
 
     del CMFDiffTool._difftypes[klass.meta_type]
+
 
 InitializeClass(CMFDiffTool)
 registerToolInterface('portal_diff', IDiffTool)

--- a/Products/CMFDiffTool/FieldDiff.py
+++ b/Products/CMFDiffTool/FieldDiff.py
@@ -27,7 +27,7 @@ class FieldDiff(BaseDiff):
         else:
             return [
                 self.filenameTitle(filename),
-                value
+                value,
             ]
 
     def getLineDiffs(self):

--- a/Products/CMFDiffTool/ListDiff.py
+++ b/Products/CMFDiffTool/ListDiff.py
@@ -28,8 +28,9 @@ class ListDiff(FieldDiff):
                 # Binding the field to an object will construct the vocabulary
                 # using a factory if necessary.
                 try:
-                    self._vocabulary = field_instance.value_type.bind(obj).vocabulary
-                except:
+                    self._vocabulary = field_instance.value_type.bind(obj).\
+                        vocabulary
+                except Exception:
                     pass
 
     def chk_hashable(self, value):
@@ -38,7 +39,7 @@ class ListDiff(FieldDiff):
         try:
             hash(value)
         except TypeError as e:
-            value = repr(e) + ": " + repr(value)
+            value = repr(e) + ': ' + repr(value)
         return value
 
     def _parseField(self, value, filename=None):
@@ -65,7 +66,8 @@ class RelationListDiff(FieldDiff):
     </div>"""
 
     def _parseField(self, value, filename=None):
-        """Take RelationValues and just return the target UID so we can compare"""
+        """ Take RelationValues and just return the target UID
+            so we can compare """
 
         if filename is None:
             # Since we only want to compare a single field, make a
@@ -74,7 +76,7 @@ class RelationListDiff(FieldDiff):
         else:
             return [
                 self.filenameTitle(filename),
-                ['/'.join(val.getPhysicalPath()) for val in value]
+                ['/'.join(val.getPhysicalPath()) for val in value],
             ]
 
     def inline_diff(self):
@@ -89,27 +91,27 @@ class RelationListDiff(FieldDiff):
                     obj_title = obj.Title()
                     obj_url = obj.absolute_url()
                     r.append(inlinediff_fmt %
-                             (css_class, "diff_sub", obj_url, obj_title))
+                             (css_class, 'diff_sub', obj_url, obj_title))
                 for i in range(blo, bhi):
                     obj = self.newValue[i]
                     obj_title = obj.Title()
                     obj_url = obj.absolute_url()
                     r.append(inlinediff_fmt %
-                             (css_class, "diff_add", obj_url, obj_title))
+                             (css_class, 'diff_add', obj_url, obj_title))
             elif tag == 'delete':
                 for i in range(alo, ahi):
                     obj = self.oldValue[i]
                     obj_title = obj.Title()
                     obj_url = obj.absolute_url()
                     r.append(inlinediff_fmt %
-                             (css_class, "diff_sub", obj_url, obj_title))
+                             (css_class, 'diff_sub', obj_url, obj_title))
             elif tag == 'insert':
                 for i in range(blo, bhi):
                     obj = self.newValue[i]
                     obj_title = obj.Title()
                     obj_url = obj.absolute_url()
                     r.append(inlinediff_fmt %
-                             (css_class, "diff_add", obj_url, obj_title))
+                             (css_class, 'diff_add', obj_url, obj_title))
             elif tag == 'equal':
                 for i in range(alo, ahi):
                     obj = self.oldValue[i]
@@ -121,33 +123,33 @@ class RelationListDiff(FieldDiff):
         return '\n'.join(r)
 
     def ndiff(self):
-        """Return a textual diff"""
+        """ Return a textual diff """
         r = []
         for tag, alo, ahi, blo, bhi in self.getLineDiffs():
             if tag == 'replace':
                 for i in range(alo, ahi):
                     obj = self.oldValue[i]
                     obj_url = obj.absolute_url()
-                    r.append("- %s" % obj_url)
+                    r.append('- %s' % obj_url)
                 for i in range(blo, bhi):
                     obj = self.newValue[i]
                     obj_url = obj.absolute_url()
-                    r.append("+ %s" % obj_url)
+                    r.append('+ %s' % obj_url)
             elif tag == 'delete':
                 for i in range(alo, ahi):
                     obj = self.oldValue[i]
                     obj_url = obj.absolute_url()
-                    r.append("- %s" % obj_url)
+                    r.append('- %s' % obj_url)
             elif tag == 'insert':
                 for i in range(blo, bhi):
                     obj = self.newValue[i]
                     obj_url = obj.absolute_url()
-                    r.append("+ %s" % obj_url)
+                    r.append('+ %s' % obj_url)
             elif tag == 'equal':
                 for i in range(alo, ahi):
                     obj = self.oldValue[i]
                     obj_url = obj.absolute_url()
-                    r.append("  %s" % obj_url)
+                    r.append('  %s' % obj_url)
             else:
                 raise ValueError('unknown tag %r', tag)
         return '\n'.join(r)

--- a/Products/CMFDiffTool/TextDiff.py
+++ b/Products/CMFDiffTool/TextDiff.py
@@ -87,14 +87,15 @@ class TextDiff(FieldDiff):
         if old_fname != new_fname:
             html.append(
                 self.inlinediff_fmt % ('%s FilenameDiff' % css_class,
-                                       old_fname, new_fname)
+                                       old_fname, new_fname),
             )
         if a != b:
             html.append(
-                self.inlinediff_fmt % (css_class, a, b)
+                self.inlinediff_fmt % (css_class, a, b),
             )
         if html:
             return linesep.join(html)
+
 
 InitializeClass(TextDiff)
 
@@ -117,5 +118,6 @@ class AsTextDiff(TextDiff):
             value = translate(_(value))
 
         return TextDiff._parseField(self, safe_unicode(value), filename)
+
 
 InitializeClass(AsTextDiff)

--- a/Products/CMFDiffTool/__init__.py
+++ b/Products/CMFDiffTool/__init__.py
@@ -47,5 +47,5 @@ tools = (CMFDiffTool.CMFDiffTool, )
 def initialize(context):
     ToolInit('CMF Diff Tool',
              tools=tools,
-             icon='tool.gif'
+             icon='tool.gif',
              ).initialize(context)

--- a/Products/CMFDiffTool/choicediff.py
+++ b/Products/CMFDiffTool/choicediff.py
@@ -80,4 +80,5 @@ class ChoiceDiff(AsTextDiff):
 
         return AsTextDiff._parseField(self, value, filename)
 
+
 InitializeClass(ChoiceDiff)

--- a/Products/CMFDiffTool/dexteritydiff.py
+++ b/Products/CMFDiffTool/dexteritydiff.py
@@ -122,7 +122,7 @@ class DexterityCompoundDiff(object):
             id2=self.id2,
             field_name=field.getName(),
             field_label=field.title,
-            schemata=schema_name
+            schemata=schema_name,
         )
 
     def _get_diff_type(self, field):
@@ -176,6 +176,7 @@ class DexterityCompoundDiff(object):
         all_fields += [(form.fields[name].field, name) for name in form.fields]
         if form.groups:
             for group in form.groups:
-                all_fields += [(group.fields[name].field, name) for name in group.fields]
+                all_fields += [(group.fields[name].field, name)
+                               for name in group.fields]
 
         return all_fields

--- a/Products/CMFDiffTool/namedfile.py
+++ b/Products/CMFDiffTool/namedfile.py
@@ -62,7 +62,7 @@ class NamedFileBinaryDiff(BinaryDiff):
     def _parseField(self, value, filename=None):
         return [
             '' if (value is None)
-            else named_file_as_str(NamedFile(data=value, filename=filename))
+            else named_file_as_str(NamedFile(data=value, filename=filename)),
         ]
 
     def inline_diff(self):
@@ -71,6 +71,7 @@ class NamedFileBinaryDiff(BinaryDiff):
         new = self._parseField(self.newValue, self.newFilename)[0]
 
         return '' if self.same else self.inlinediff_fmt % (css_class, old, new)
+
 
 InitializeClass(NamedFileBinaryDiff)
 
@@ -131,7 +132,7 @@ class NamedFileListDiff(ListDiff):
 
         def is_same_dict(d1, d2):
             return is_same(
-                d1['data'], d1['filename'], d2['data'], d2['filename']
+                d1['data'], d1['filename'], d2['data'], d2['filename'],
             )
 
         return '\n'.join([
@@ -139,5 +140,6 @@ class NamedFileListDiff(ListDiff):
              if is_same_dict(d_old, d_new) else self.inlinediff_fmt
              % (css_class, d_old['repr'], d_new['repr'])
              ) for (d_old, d_new) in zip(old_data, new_data)])
+
 
 InitializeClass(NamedFileListDiff)

--- a/Products/CMFDiffTool/testing.py
+++ b/Products/CMFDiffTool/testing.py
@@ -17,6 +17,7 @@ TEST_CONTENT_TYPE_ID = 'TestContentType'
 VOCABULARY_TUPLES = [
     (u'first_value', u'First Title'),
     (u'second_value', None),
+    (u'third_value', u'Third Title'),
 ]
 
 VOCABULARY = SimpleVocabulary(
@@ -81,6 +82,13 @@ class DXLayer(PloneSandboxLayer):
                         <title>Choice</title>
                         <required>False</required>
                         <vocabulary>Products.CMFDiffTool.testing.VOCABULARY</vocabulary>
+                    </field>
+                    <field name="choices" type="zope.schema.List">
+                        <title>Choices</title>
+                        <required>False</required>
+                        <value_type type="zope.schema.Choice">
+                            <vocabulary>Products.CMFDiffTool.testing.VOCABULARY</vocabulary>
+                        </value_type>
                     </field>
                 </schema>
             </model>

--- a/Products/CMFDiffTool/testing.py
+++ b/Products/CMFDiffTool/testing.py
@@ -43,7 +43,7 @@ class DXLayer(PloneSandboxLayer):
         sm.registerUtility(
             component=vocabulary_factory,
             provided=IVocabularyFactory,
-            name=u'Products.CMFDiffTool.testing.VOCABULARY'
+            name=u'Products.CMFDiffTool.testing.VOCABULARY',
         )
 
         fti = DexterityFTI(
@@ -92,9 +92,10 @@ class DXLayer(PloneSandboxLayer):
                     </field>
                 </schema>
             </model>
-            '''
+            ''',
         )
         types_tool._setObject(TEST_CONTENT_TYPE_ID, fti)
+
 
 PACKAGE_DX_FIXTURE = DXLayer()
 
@@ -115,7 +116,8 @@ if six.PY2:
 
     PACKAGE_AT_FIXTURE = ATLayer()
     CMFDiffToolATLayer = FunctionalTesting(
-        bases=(PACKAGE_AT_FIXTURE, ), name='Products.CMFDiffTool.AT:functional')
+        bases=(PACKAGE_AT_FIXTURE, ),
+        name='Products.CMFDiffTool.AT:functional')
 
 
 CMFDiffToolDXLayer = FunctionalTesting(

--- a/Products/CMFDiffTool/tests/testATCompoundDiff.py
+++ b/Products/CMFDiffTool/tests/testATCompoundDiff.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import six
 
+
 if six.PY2:
     from .BaseTestCase import BaseATTestCase
     from Products.Archetypes import atapi
@@ -11,14 +12,14 @@ if six.PY2:
     from zope.interface import alsoProvides
     from zope.interface import noLongerProvides
 
-
     class TestATCompoundDiff(BaseATTestCase):
         """Test the portal_diff tool"""
 
         def testCompoundDiff(self):
             first = self.folder.invokeFactory('Document', 'extended-document')
             first = self.folder[first]
-            second = self.folder.invokeFactory('Document', 'extended-document2')
+            second = self.folder.invokeFactory('Document',
+                                               'extended-document2')
             second = self.folder[second]
             # Change a value
             first.setText('<p>Body1</p>', mimetype='text/html')
@@ -68,7 +69,7 @@ if six.PY2:
                         noLongerProvides(instance, IHighlighted)
 
             class TestSchemaExtender(Extender):
-                adapts(ATDocument)
+                adapts(ATDocument)  # noqa: D001
                 fields = [
                     HighlightedField('schemaextender_test',
                                      schemata='settings',
@@ -78,13 +79,15 @@ if six.PY2:
                                      ),
                 ]
 
-            """Ensure that tool instances implement the portal_diff interface"""
+            """ Ensure that tool instances implement the portal_diff
+            interface """
             provideAdapter(TestSchemaExtender,
-                           name=u"archetypes.schemaextender.tests")
+                           name=u'archetypes.schemaextender.tests')
 
             first = self.folder.invokeFactory('Document', 'extended-document')
             first = self.folder[first]
-            second = self.folder.invokeFactory('Document', 'extended-document2')
+            second = self.folder.invokeFactory('Document',
+                                               'extended-document2')
             second = self.folder[second]
             # Change the value
             alsoProvides(second, IHighlighted)

--- a/Products/CMFDiffTool/tests/testChangeSet.py
+++ b/Products/CMFDiffTool/tests/testChangeSet.py
@@ -37,7 +37,8 @@ class TestChangeSet(TestCase):
         self.folder.invokeFactory('Document', 'doc1', title='My Title')
         self.folder.manage_pasteObjects(
             self.folder.manage_copyObjects(['doc1']))
-        cdd = DexterityCompoundDiff(self.folder['doc1'], self.folder['doc1'], '')
+        cdd = DexterityCompoundDiff(self.folder['doc1'], self.folder['doc1'],
+                                    '')
         self.len_diff = len(cdd._diffs)
 
     def setupTestFolders(self):
@@ -220,7 +221,8 @@ class TestChangeSet(TestCase):
             # We don't have an orderable folder give up
             return
 
-        self.cs.computeDiff(self.folder['folder1'], self.folder['copy_of_folder1'])
+        self.cs.computeDiff(self.folder['folder1'],
+                            self.folder['copy_of_folder1'])
         diffs = self.cs.getDiffs()
         self.assertEqual(len(diffs), 14)
         self.assertFalse(diffs[0].same)

--- a/Products/CMFDiffTool/tests/testFieldDiff.py
+++ b/Products/CMFDiffTool/tests/testFieldDiff.py
@@ -27,10 +27,10 @@ class B:
 
 
 class U:
-    attribute = u"\xfcnicode value"
+    attribute = u'\xfcnicode value'
 
     def method(self):
-        return u"different method val\xfce"
+        return u'different method val\xfce'
 
 
 class TestFieldDiff(TestCase):
@@ -121,7 +121,7 @@ class TestFieldDiff(TestCase):
         expected = '- value%s+ different value' % linesep
         fd = FieldDiff(a, b, 'attribute')
         self.assertEqual(fd.ndiff(), expected)
-        expected = u"- value%s+ \xfcnicode value" % linesep
+        expected = u'- value%s+ \xfcnicode value' % linesep
         fd = FieldDiff(a, uu, 'attribute')
         self.assertEqual(fd.ndiff(), expected)
 

--- a/Products/CMFDiffTool/tests/testListDiff.py
+++ b/Products/CMFDiffTool/tests/testListDiff.py
@@ -6,10 +6,10 @@ from os import linesep
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from Products.CMFDiffTool import testing
-from Products.CMFDiffTool.choicediff import title_or_value
 from Products.CMFDiffTool.interfaces import IDifference
 from Products.CMFDiffTool.ListDiff import ListDiff
 from Products.CMFDiffTool.tests.BaseTestCase import BaseDXTestCase
+
 
 _marker = []
 
@@ -23,11 +23,11 @@ class B:
 
 
 class C:
-    attribute = {"a": 1, "b": 2}
+    attribute = {'a': 1, 'b': 2}
 
 
 class D:
-    attribute = {"a": 1, "b": 2, "c": 3}
+    attribute = {'a': 1, 'b': 2, 'c': 3}
 
 
 class TestListDiff(BaseDXTestCase):
@@ -66,7 +66,7 @@ class TestListDiff(BaseDXTestCase):
         diff = ListDiff(a, b, 'attribute')
         self.assertEqual([('insert', 0, 0, 0, 1)], diff.getLineDiffs())
 
-        b.attribute = ""
+        b.attribute = ''
         diff = ListDiff(a, b, 'attribute')
         self.assertEqual([('insert', 0, 0, 0, 1)], diff.getLineDiffs())
 
@@ -142,7 +142,8 @@ class TestListDiff(BaseDXTestCase):
     <div class="diff_add">First Title</div>
 </div>'''
         self._test_diff_list([],
-                             [testing.VOCABULARY_TUPLES[0][0]], False, expected)
+                             [testing.VOCABULARY_TUPLES[0][0]],
+                             False, expected)
         # changed: replaced unique value by another one, displaying titles
         expected = u'''<div class="InlineDiff">
     <div class="diff_sub">First Title</div>
@@ -153,7 +154,8 @@ class TestListDiff(BaseDXTestCase):
     <div class="diff_add">Third Title</div>
 </div>'''
         self._test_diff_list([testing.VOCABULARY_TUPLES[0][0]],
-                             [testing.VOCABULARY_TUPLES[2][0]], False, expected)
+                             [testing.VOCABULARY_TUPLES[2][0]],
+                             False, expected)
         # changed: replaced multiple values by others, displaying titles
         expected = u'''<div class="InlineDiff">
     <div class="diff_sub">First Title</div>
@@ -164,8 +166,11 @@ class TestListDiff(BaseDXTestCase):
     <div class="diff_sub"></div>
     <div class="diff_add">Third Title</div>
 </div>'''
-        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0], testing.VOCABULARY_TUPLES[1][0]],
-                             [testing.VOCABULARY_TUPLES[1][0], testing.VOCABULARY_TUPLES[2][0]], False, expected)
+        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0],
+                              testing.VOCABULARY_TUPLES[1][0]],
+                             [testing.VOCABULARY_TUPLES[1][0],
+                              testing.VOCABULARY_TUPLES[2][0]],
+                             False, expected)
         # changed: replaced multiple values by others, displaying titles
         expected = u'''<div class="InlineDiff">
     <div class="diff_sub"></div>
@@ -176,8 +181,11 @@ class TestListDiff(BaseDXTestCase):
     <div class="diff_sub">second_value</div>
     <div class="diff_add"></div>
 </div>'''
-        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0], testing.VOCABULARY_TUPLES[1][0]],
-                             [testing.VOCABULARY_TUPLES[2][0], testing.VOCABULARY_TUPLES[0][0]], False, expected)
+        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0],
+                              testing.VOCABULARY_TUPLES[1][0]],
+                             [testing.VOCABULARY_TUPLES[2][0],
+                              testing.VOCABULARY_TUPLES[0][0]],
+                             False, expected)
         # changed: removed values, displaying titles
         expected = u'''<div class="InlineDiff">
     <div class="diff_sub">First Title</div>
@@ -187,7 +195,8 @@ class TestListDiff(BaseDXTestCase):
     <div class="diff_sub">second_value</div>
     <div class="diff_add"></div>
 </div>'''
-        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0], testing.VOCABULARY_TUPLES[1][0]],
+        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0],
+                              testing.VOCABULARY_TUPLES[1][0]],
                              [], False, expected)
 
     def _test_diff_list(self, value1, value2, same, expected):

--- a/Products/CMFDiffTool/tests/testListDiff.py
+++ b/Products/CMFDiffTool/tests/testListDiff.py
@@ -3,10 +3,13 @@
 # CMFDiffTool tests
 #
 from os import linesep
-from plone.app.testing import PLONE_INTEGRATION_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from Products.CMFDiffTool import testing
+from Products.CMFDiffTool.choicediff import title_or_value
+from Products.CMFDiffTool.interfaces import IDifference
 from Products.CMFDiffTool.ListDiff import ListDiff
-from unittest import TestCase
-
+from Products.CMFDiffTool.tests.BaseTestCase import BaseDXTestCase
 
 _marker = []
 
@@ -27,14 +30,26 @@ class D:
     attribute = {"a": 1, "b": 2, "c": 3}
 
 
-class TestListDiff(TestCase):
+class TestListDiff(BaseDXTestCase):
     """Test the ListDiff class"""
 
-    layer = PLONE_INTEGRATION_TESTING
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        self.portal.invokeFactory(
+            testing.TEST_CONTENT_TYPE_ID,
+            'obj1',
+        )
+        self.portal.invokeFactory(
+            testing.TEST_CONTENT_TYPE_ID,
+            'obj2',
+        )
+
+        self.obj1 = self.portal['obj1']
+        self.obj2 = self.portal['obj2']
 
     def testInterface(self):
         """Ensure that tool instances implement the portal_diff interface"""
-        from Products.CMFDiffTool.interfaces.portal_diff import IDifference
         self.assertTrue(IDifference.implementedBy(ListDiff))
 
     def testInvalidValue(self):
@@ -110,6 +125,76 @@ class TestListDiff(TestCase):
     <div class="diff_add">4</div>
 </div>"""
         diff = ListDiff(a, b, 'attribute')
+        self.assertEqual(diff.inline_diff(), expected)
+
+    def test_inline_diff_vocabulary(self):
+        # unchanged, with vocabulary title
+        expected = u'<div class="InlineDiff">First Title</div>'
+        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0]],
+                             [testing.VOCABULARY_TUPLES[0][0]], True, expected)
+        # unchanged, without vocabulary title
+        expected = u'<div class="InlineDiff">second_value</div>'
+        self._test_diff_list([testing.VOCABULARY_TUPLES[1][0]],
+                             [testing.VOCABULARY_TUPLES[1][0]], True, expected)
+        # changed: add value, with vocabulary title
+        expected = u'''<div class="InlineDiff">
+    <div class="diff_sub"></div>
+    <div class="diff_add">First Title</div>
+</div>'''
+        self._test_diff_list([],
+                             [testing.VOCABULARY_TUPLES[0][0]], False, expected)
+        # changed: replaced unique value by another one, displaying titles
+        expected = u'''<div class="InlineDiff">
+    <div class="diff_sub">First Title</div>
+    <div class="diff_add"></div>
+</div>
+<div class="InlineDiff">
+    <div class="diff_sub"></div>
+    <div class="diff_add">Third Title</div>
+</div>'''
+        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0]],
+                             [testing.VOCABULARY_TUPLES[2][0]], False, expected)
+        # changed: replaced multiple values by others, displaying titles
+        expected = u'''<div class="InlineDiff">
+    <div class="diff_sub">First Title</div>
+    <div class="diff_add"></div>
+</div>
+<div class="InlineDiff">second_value</div>
+<div class="InlineDiff">
+    <div class="diff_sub"></div>
+    <div class="diff_add">Third Title</div>
+</div>'''
+        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0], testing.VOCABULARY_TUPLES[1][0]],
+                             [testing.VOCABULARY_TUPLES[1][0], testing.VOCABULARY_TUPLES[2][0]], False, expected)
+        # changed: replaced multiple values by others, displaying titles
+        expected = u'''<div class="InlineDiff">
+    <div class="diff_sub"></div>
+    <div class="diff_add">Third Title</div>
+</div>
+<div class="InlineDiff">First Title</div>
+<div class="InlineDiff">
+    <div class="diff_sub">second_value</div>
+    <div class="diff_add"></div>
+</div>'''
+        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0], testing.VOCABULARY_TUPLES[1][0]],
+                             [testing.VOCABULARY_TUPLES[2][0], testing.VOCABULARY_TUPLES[0][0]], False, expected)
+        # changed: removed values, displaying titles
+        expected = u'''<div class="InlineDiff">
+    <div class="diff_sub">First Title</div>
+    <div class="diff_add"></div>
+</div>
+<div class="InlineDiff">
+    <div class="diff_sub">second_value</div>
+    <div class="diff_add"></div>
+</div>'''
+        self._test_diff_list([testing.VOCABULARY_TUPLES[0][0], testing.VOCABULARY_TUPLES[1][0]],
+                             [], False, expected)
+
+    def _test_diff_list(self, value1, value2, same, expected):
+        self.obj1.choices = value1
+        self.obj2.choices = value2
+        diff = ListDiff(self.obj1, self.obj2, 'choices')
+        self.assertEqual(diff.same, same)
         self.assertEqual(diff.inline_diff(), expected)
 
     def testGetLineDictDiffsSame(self):

--- a/Products/CMFDiffTool/tests/testTextDiff.py
+++ b/Products/CMFDiffTool/tests/testTextDiff.py
@@ -5,8 +5,6 @@ from plone.app.testing import PLONE_INTEGRATION_TESTING
 from Products.CMFDiffTool.TextDiff import TextDiff
 from unittest import TestCase
 
-import six
-
 
 _marker = []
 

--- a/Products/CMFDiffTool/tests/test_binarydiff.py
+++ b/Products/CMFDiffTool/tests/test_binarydiff.py
@@ -16,14 +16,14 @@ class BinaryDiffTestCase(BaseDXTestCase):
         self.portal.invokeFactory(
             testing.TEST_CONTENT_TYPE_ID,
             'obj1',
-            file=NamedFile(data='contents', filename=u'blah.txt')
+            file=NamedFile(data='contents', filename=u'blah.txt'),
         )
         obj1 = self.portal['obj1']
 
         self.portal.invokeFactory(
             testing.TEST_CONTENT_TYPE_ID,
             'obj2',
-            file=NamedFile(data='contents', filename=u'bleh.txt')
+            file=NamedFile(data='contents', filename=u'bleh.txt'),
         )
         obj2 = self.portal['obj2']
 
@@ -36,14 +36,14 @@ class BinaryDiffTestCase(BaseDXTestCase):
         self.portal.invokeFactory(
             testing.TEST_CONTENT_TYPE_ID,
             'obj1',
-            file=NamedFile(data='contents', filename=u'f.txt')
+            file=NamedFile(data='contents', filename=u'f.txt'),
         )
         obj1 = self.portal['obj1']
 
         self.portal.invokeFactory(
             testing.TEST_CONTENT_TYPE_ID,
             'obj2',
-            file=NamedFile(data='different contents', filename=u'f.txt')
+            file=NamedFile(data='different contents', filename=u'f.txt'),
         )
         obj2 = self.portal['obj2']
 
@@ -56,14 +56,14 @@ class BinaryDiffTestCase(BaseDXTestCase):
         self.portal.invokeFactory(
             testing.TEST_CONTENT_TYPE_ID,
             'obj1',
-            file=NamedFile(data='contents', filename=u'f.txt')
+            file=NamedFile(data='contents', filename=u'f.txt'),
         )
         obj1 = self.portal['obj1']
 
         self.portal.invokeFactory(
             testing.TEST_CONTENT_TYPE_ID,
             'obj2',
-            file=NamedFile(data='contents', filename=u'f.txt')
+            file=NamedFile(data='contents', filename=u'f.txt'),
         )
         obj2 = self.portal['obj2']
 

--- a/Products/CMFDiffTool/tests/test_dexteritydiff.py
+++ b/Products/CMFDiffTool/tests/test_dexteritydiff.py
@@ -13,7 +13,6 @@ from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 
 
-
 class DexterityDiffTestCase(BaseDXTestCase):
 
     def setUp(self):
@@ -26,7 +25,7 @@ class DexterityDiffTestCase(BaseDXTestCase):
             'obj1',
             title=u'Object 1',
             description=u'Desc 1',
-            text=u'Text 1'
+            text=u'Text 1',
         )
         obj1 = self.portal['obj1']
 
@@ -34,7 +33,7 @@ class DexterityDiffTestCase(BaseDXTestCase):
             testing.TEST_CONTENT_TYPE_ID,
             'obj2',
             title=u'Object 2',
-            text=u'Text 2'
+            text=u'Text 2',
         )
         obj2 = self.portal['obj2']
 
@@ -118,7 +117,7 @@ class DexterityDiffTestCase(BaseDXTestCase):
             'obj1',
             title=u'Object 1',
             description=u'Desc 1',
-            text=u'Text 1'
+            text=u'Text 1',
         )
         obj1 = self.portal['obj1']
 

--- a/Products/CMFDiffTool/tests/test_filelistdiff.py
+++ b/Products/CMFDiffTool/tests/test_filelistdiff.py
@@ -19,42 +19,42 @@ class AsTextDiffTestCase(unittest.TestCase):
         self._test_diff_files(
             [('data1', u'filename1')],
             [('data2', u'filename2')],
-            False
+            False,
         )
         self._test_diff_files(
             [('data1', u'filename1'), ('datax', u'filenamex')],
             [('data1', u'filename1'), ('datay', u'filenamey')],
-            False
+            False,
         )
         self._test_diff_files(
             [('data1', u'filename1'), ('datax', u'filenamex')],
             [('datax', u'filenamex'), ('data1', u'filename1')],
-            False
+            False,
         )
         self._test_diff_files(
             [('data1', u'filename1')],
             [('data1', u'filename1'), ('datax', u'filenamex')],
-            False
+            False,
         )
         self._test_diff_files(
             [('data1', u'filename1')],
             [('data1', u'filename1')],
-            True
+            True,
         )
         self._test_diff_files(
             [('data1', u'filename1'), ('datax', u'filenamex')],
             [('data1', u'filename1'), ('datax', u'filenamex')],
-            True
+            True,
         )
         self._test_diff_files(
             [('data1', u'filename1'), ('datax', u'filenamex')],
             None,
-            False
+            False,
         )
         self._test_diff_files(
             [('data1', u'filename1'), ('datax', u'filenamex')],
             [],
-            False
+            False,
         )
         self._test_diff_files(None, None, True)
         self._test_diff_files([], [], True)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,7 +1,6 @@
 [buildout]
 extends =
-    https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
-    plone-4.3.x.cfg
+    https://raw.github.com/collective/buildout.plonetest/master/test-5.x.cfg
 package-name = Products.CMFDiffTool
 package-extras = [test]
 test-eggs = Pillow
@@ -18,6 +17,10 @@ allow-hosts =
     prdownloads.sourceforge.net
     effbot.org
     dist.plone.org
+
+[test]
+eggs +=
+    ipdb
 
 [omelette]
 recipe = collective.recipe.omelette

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -29,7 +29,7 @@ eggs = ${test:eggs}
 [code-analysis]
 recipe = plone.recipe.codeanalysis [recommended]
 directory = ${buildout:directory}/Products
-flake8-max-complexity = 20
+flake8-max-complexity = 22
 # If todo markers are marked as problems, no todomarkers will be written
 # Don't show plone.api advertisement
 # Don't checko for % formatter


### PR DESCRIPTION
Before was displayed the field value... Now the vocabulary term title.
Alse used plone5 in buildout.
Corrected plenty annoying flake8 errors.
Seems plone4 compatible: only tests counting differences are failing because a difference on the 'id' field is not present when using plone 4 plone.app.contenttypes version.
