### PR TITLE
Escape html in diffs.

### DIFF
--- a/Products/CMFDiffTool/BinaryDiff.py
+++ b/Products/CMFDiffTool/BinaryDiff.py
@@ -3,6 +3,7 @@ from AccessControl.class_init import InitializeClass
 from os import linesep
 from Products.CMFDiffTool.BaseDiff import _getValue
 from Products.CMFDiffTool.FieldDiff import FieldDiff
+from Products.CMFDiffTool.utils import html_encode
 
 
 class BinaryDiff(FieldDiff):
@@ -50,8 +51,8 @@ class BinaryDiff(FieldDiff):
         if self.oldFilename != self.newFilename:
             html.append(
                 self.inlinediff_fmt % (css_class,
-                                       self.filenameTitle(self.oldFilename),
-                                       self.filenameTitle(self.newFilename)),
+                                       self.filenameTitle(html_encode(self.oldFilename)),
+                                       self.filenameTitle(html_encode(self.newFilename))),
             )
 
         if html:

--- a/Products/CMFDiffTool/CMFDTHtmlDiff.py
+++ b/Products/CMFDiffTool/CMFDTHtmlDiff.py
@@ -2,6 +2,7 @@
 from AccessControl.class_init import InitializeClass
 from Products.CMFDiffTool.libs import htmldiff
 from Products.CMFDiffTool.TextDiff import TextDiff
+from Products.CMFDiffTool.utils import html_encode
 
 
 # Give it a dumb name so it doesn't conflict with all the other html diffs
@@ -18,7 +19,7 @@ class CMFDTHtmlDiff(TextDiff):
                                        filename=self.oldFilename))
         b = '\n'.join(self._parseField(self.newValue,
                                        filename=self.newFilename))
-        return htmldiff.htmldiff(a, b)
+        return htmldiff.htmldiff(html_encode(a), html_encode(b))
 
     def _parseField(self, value, filename=None):
         """Use the field's raw value if available."""

--- a/Products/CMFDiffTool/FieldDiff.py
+++ b/Products/CMFDiffTool/FieldDiff.py
@@ -2,6 +2,7 @@
 from AccessControl.class_init import InitializeClass
 from Products.CMFDiffTool.BaseDiff import _getValue
 from Products.CMFDiffTool.BaseDiff import BaseDiff
+from Products.CMFDiffTool.utils import html_encode
 from six.moves import range
 
 import difflib
@@ -80,18 +81,18 @@ class FieldDiff(BaseDiff):
         for tag, alo, ahi, blo, bhi in self.getLineDiffs():
             if tag == 'replace':
                 for i in range(alo, ahi):
-                    r.append(inlinediff_fmt % (css_class, a[i], ''))
+                    r.append(inlinediff_fmt % (css_class, html_encode(a[i]), ''))
                 for i in range(blo, bhi):
-                    r.append(inlinediff_fmt % (css_class, '', b[i]))
+                    r.append(inlinediff_fmt % (css_class, '', html_encode(b[i])))
             elif tag == 'delete':
                 for i in range(alo, ahi):
-                    r.append(inlinediff_fmt % (css_class, a[i], ''))
+                    r.append(inlinediff_fmt % (css_class, html_encode(a[i]), ''))
             elif tag == 'insert':
                 for i in range(blo, bhi):
-                    r.append(inlinediff_fmt % (css_class, '', b[i]))
+                    r.append(inlinediff_fmt % (css_class, '', html_encode(b[i])))
             elif tag == 'equal':
                 for i in range(alo, ahi):
-                    r.append(same_fmt % (css_class, a[i]))
+                    r.append(same_fmt % (css_class, html_encode(a[i])))
             else:
                 raise ValueError('unknown tag "%s"' % tag)
         return '\n'.join(r)

--- a/Products/CMFDiffTool/ListDiff.py
+++ b/Products/CMFDiffTool/ListDiff.py
@@ -4,6 +4,7 @@ from plone.dexterity.interfaces import IDexterityContent
 from Products.CMFDiffTool.choicediff import get_field_object
 from Products.CMFDiffTool.choicediff import title_or_value
 from Products.CMFDiffTool.FieldDiff import FieldDiff
+from Products.CMFDiffTool.utils import html_encode
 from six.moves import range
 
 
@@ -88,34 +89,34 @@ class RelationListDiff(FieldDiff):
             if tag == 'replace':
                 for i in range(alo, ahi):
                     obj = self.oldValue[i]
-                    obj_title = obj.Title()
+                    obj_title = html_encode(obj.Title())
                     obj_url = obj.absolute_url()
                     r.append(inlinediff_fmt %
                              (css_class, 'diff_sub', obj_url, obj_title))
                 for i in range(blo, bhi):
                     obj = self.newValue[i]
-                    obj_title = obj.Title()
+                    obj_title = html_encode(obj.Title())
                     obj_url = obj.absolute_url()
                     r.append(inlinediff_fmt %
                              (css_class, 'diff_add', obj_url, obj_title))
             elif tag == 'delete':
                 for i in range(alo, ahi):
                     obj = self.oldValue[i]
-                    obj_title = obj.Title()
+                    obj_title = html_encode(obj.Title())
                     obj_url = obj.absolute_url()
                     r.append(inlinediff_fmt %
                              (css_class, 'diff_sub', obj_url, obj_title))
             elif tag == 'insert':
                 for i in range(blo, bhi):
                     obj = self.newValue[i]
-                    obj_title = obj.Title()
+                    obj_title = html_encode(obj.Title())
                     obj_url = obj.absolute_url()
                     r.append(inlinediff_fmt %
                              (css_class, 'diff_add', obj_url, obj_title))
             elif tag == 'equal':
                 for i in range(alo, ahi):
                     obj = self.oldValue[i]
-                    obj_title = obj.Title()
+                    obj_title = html_encode(obj.Title())
                     obj_url = obj.absolute_url()
                     r.append(same_fmt % (css_class, obj_url, obj_title))
             else:

--- a/Products/CMFDiffTool/TextDiff.py
+++ b/Products/CMFDiffTool/TextDiff.py
@@ -3,6 +3,7 @@ from AccessControl.class_init import InitializeClass
 from os import linesep
 from Products.CMFDiffTool import CMFDiffToolMessageFactory as _
 from Products.CMFDiffTool.FieldDiff import FieldDiff
+from Products.CMFDiffTool.utils import html_encode
 from Products.CMFDiffTool.utils import safe_unicode
 from Products.CMFDiffTool.utils import safe_utf8
 from zope.component.hooks import getSite
@@ -87,11 +88,11 @@ class TextDiff(FieldDiff):
         if old_fname != new_fname:
             html.append(
                 self.inlinediff_fmt % ('%s FilenameDiff' % css_class,
-                                       old_fname, new_fname),
+                                       html_encode(old_fname), html_encode(new_fname)),
             )
         if a != b:
             html.append(
-                self.inlinediff_fmt % (css_class, a, b),
+                self.inlinediff_fmt % (css_class, html_encode(a), html_encode(b)),
             )
         if html:
             return linesep.join(html)

--- a/Products/CMFDiffTool/namedfile.py
+++ b/Products/CMFDiffTool/namedfile.py
@@ -4,6 +4,7 @@ from plone.namedfile import NamedFile
 from Products.CMFDiffTool.BinaryDiff import BinaryDiff
 from Products.CMFDiffTool.ListDiff import ListDiff
 from Products.CMFDiffTool.TextDiff import TextDiff
+from Products.CMFDiffTool.utils import html_encode
 
 
 FILE_FIELD_TYPES = []
@@ -70,7 +71,7 @@ class NamedFileBinaryDiff(BinaryDiff):
         old = self._parseField(self.oldValue, self.oldFilename)[0]
         new = self._parseField(self.newValue, self.newFilename)[0]
 
-        return '' if self.same else self.inlinediff_fmt % (css_class, old, new)
+        return '' if self.same else self.inlinediff_fmt % (css_class, html_encode(old), html_encode(new))
 
 
 InitializeClass(NamedFileBinaryDiff)
@@ -136,9 +137,9 @@ class NamedFileListDiff(ListDiff):
             )
 
         return '\n'.join([
-            ((self.same_fmt % (css_class, d_old['repr']))
+            ((self.same_fmt % (css_class, html_encode(d_old['repr'])))
              if is_same_dict(d_old, d_new) else self.inlinediff_fmt
-             % (css_class, d_old['repr'], d_new['repr'])
+             % (css_class, html_encode(d_old['repr']), html_encode(d_new['repr']))
              ) for (d_old, d_new) in zip(old_data, new_data)])
 
 

--- a/Products/CMFDiffTool/tests/testFieldDiff.py
+++ b/Products/CMFDiffTool/tests/testFieldDiff.py
@@ -33,6 +33,13 @@ class U:
         return u'different method val\xfce'
 
 
+class H:
+    attribute = '<script>alert("Hacker value")</script>'
+
+    def method(self):
+        return '<script>alert("Hacker method value")</script>'
+
+
 class TestFieldDiff(TestCase):
     """Test the FieldDiff class"""
 
@@ -163,3 +170,40 @@ class TestFieldDiff(TestCase):
         self.assertEqual(diff, ['- True'])
         dump('+', [False], 0, 1, diff)
         self.assertEqual(diff, ['- True', '+ False'])
+
+    def test_inline_diff_same(self):
+        """Test inline diff for attribute with same value"""
+        a = A()
+        uu = U()
+        h = H()
+        # We mostly just want to check that the inline diff renders without error.
+        fd = FieldDiff(a, a, 'attribute')
+        self.assertIn('class="InlineDiff"', fd.inline_diff())
+        fd = FieldDiff(uu, uu, 'attribute')
+        self.assertIn('class="InlineDiff"', fd.inline_diff())
+        self.assertNotIn("&gt;", fd.inline_diff())
+        fd = FieldDiff(h, h, 'attribute')
+        self.assertIn('class="InlineDiff"', fd.inline_diff())
+        # h.attribute contains a script, and this should be escaped.
+        self.assertNotIn(h.attribute, fd.inline_diff())
+        self.assertIn("&gt;", fd.inline_diff())
+
+    def test_inline_diff_different(self):
+        """Test inline diff for attribute with different value"""
+        a = A()
+        uu = U()
+        h = H()
+        fd = FieldDiff(a, uu, 'attribute')
+        self.assertIn('class="InlineDiff"', fd.inline_diff())
+        fd = FieldDiff(uu, a, 'attribute')
+        self.assertIn('class="InlineDiff"', fd.inline_diff())
+        self.assertNotIn("&gt;", fd.inline_diff())
+        fd = FieldDiff(uu, h, 'attribute')
+        self.assertIn('class="InlineDiff"', fd.inline_diff())
+        # h.attribute contains a script, and this should be escaped.
+        self.assertNotIn(h.attribute, fd.inline_diff())
+        fd = FieldDiff(h, uu, 'attribute')
+        self.assertIn('class="InlineDiff"', fd.inline_diff())
+        # h.attribute contains a script, and this should be escaped.
+        self.assertNotIn(h.attribute, fd.inline_diff())
+        self.assertIn("&gt;", fd.inline_diff())

--- a/Products/CMFDiffTool/tests/testListDiff.py
+++ b/Products/CMFDiffTool/tests/testListDiff.py
@@ -22,12 +22,20 @@ class B:
     attribute = [1, 2, 3, 4]
 
 
+class HList:
+    attribute = ['<script>alert("Hacker value")</script>']
+
+
 class C:
     attribute = {'a': 1, 'b': 2}
 
 
 class D:
     attribute = {'a': 1, 'b': 2, 'c': 3}
+
+
+class HDict:
+    attribute = {'a': '<script>alert("Hacker value")</script>'}
 
 
 class TestListDiff(BaseDXTestCase):
@@ -126,6 +134,22 @@ class TestListDiff(BaseDXTestCase):
 </div>"""
         diff = ListDiff(a, b, 'attribute')
         self.assertEqual(diff.inline_diff(), expected)
+
+    def test_inline_diff_hacker_list(self):
+        a = A()
+        h = HList()
+        diff = ListDiff(a, h, 'attribute')
+        # The script tag should be escaped.
+        self.assertNotIn("<script", diff.inline_diff())
+        self.assertIn("&gt;", diff.inline_diff())
+
+    def test_inline_diff_hacker_dict(self):
+        d = D()
+        h = HDict()
+        diff = ListDiff(d, h, 'attribute')
+        # The script tag should be escaped.
+        self.assertNotIn("<script", diff.inline_diff())
+        self.assertIn("&gt;", diff.inline_diff())
 
     def test_inline_diff_vocabulary(self):
         # unchanged, with vocabulary title

--- a/Products/CMFDiffTool/tests/testTextDiff.py
+++ b/Products/CMFDiffTool/tests/testTextDiff.py
@@ -23,6 +23,13 @@ class B:
         return 'method 過労死'
 
 
+class H:
+    attribute = '<script>alert("Hacker value")</script>'
+
+    def method(self):
+        return '<script>alert("Hacker method value")</script>'
+
+
 class TestTextDiff(TestCase):
     """Test the TextDiff class"""
     layer = PLONE_INTEGRATION_TESTING
@@ -107,6 +114,7 @@ class TestTextDiff(TestCase):
         """Test text diff output with different value"""
         a = A()
         b = B()
+        h = H()
         expected = """
     <table class="diff" id="difflib_chg_to0__top"
            cellspacing="0" cellpadding="0" rules="groups" >
@@ -119,3 +127,22 @@ class TestTextDiff(TestCase):
     </table>"""  # NOQA
         fd = TextDiff(a, b, 'attribute')
         self.assertEqual(fd.html_diff(), expected)
+
+        fd = TextDiff(a, h, 'attribute')
+        # h.attribute contains a script, and this should be escaped.
+        self.assertNotIn(h.attribute, fd.html_diff())
+        self.assertIn("&gt;", fd.html_diff())
+
+    def testInlineDiff(self):
+        """Test text inline diff output with different value"""
+        a = A()
+        b = B()
+        h = H()
+        fd = TextDiff(a, b, 'attribute')
+        self.assertIn('class="InlineDiff FilenameDiff"', fd.inline_diff())
+
+        fd = TextDiff(a, h, 'attribute')
+        self.assertIn('class="InlineDiff FilenameDiff"', fd.inline_diff())
+        # h.attribute contains a script, and this should be escaped.
+        self.assertNotIn(h.attribute, fd.inline_diff())
+        self.assertIn("&gt;", fd.inline_diff())

--- a/Products/CMFDiffTool/tests/test_binarydiff.py
+++ b/Products/CMFDiffTool/tests/test_binarydiff.py
@@ -2,6 +2,7 @@
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.namedfile.file import NamedFile
+from Products.CMFDiffTool import BinaryDiff
 from Products.CMFDiffTool import namedfile
 from Products.CMFDiffTool import testing
 from Products.CMFDiffTool.interfaces import IDifference
@@ -70,3 +71,40 @@ class BinaryDiffTestCase(BaseDXTestCase):
         diff = namedfile.NamedFileBinaryDiff(obj1, obj2, 'file')
         self.assertTrue(IDifference.providedBy(diff))
         self.assertTrue(diff.same)
+
+    def test_should_escape_html(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        self.portal.invokeFactory(
+            testing.TEST_CONTENT_TYPE_ID,
+            'obj1',
+            file=NamedFile(data='contents', filename=u'blah.txt'),
+        )
+        obj1 = self.portal['obj1']
+
+        self.portal.invokeFactory(
+            testing.TEST_CONTENT_TYPE_ID,
+            'obj2',
+            file=NamedFile(data='<script>alert("Hacker data")</script>', filename=u'<script>alert("Hacker filename")</script>.txt'),
+        )
+        obj2 = self.portal['obj2']
+
+        diff = namedfile.NamedFileBinaryDiff(obj1, obj2, 'file')
+        self.assertTrue(IDifference.providedBy(diff))
+        self.assertFalse(diff.same)
+        # The script tag should be escaped.
+        self.assertNotIn("<script", diff.inline_diff())
+        self.assertIn("&gt;", diff.inline_diff())
+
+        # Test the more basic BinaryDiff.
+        # It only compares the file names.
+        # It uses the 'getFilename' method of the file,
+        # which namedfiles do not have.  So we hack it.
+        obj1.file.getFilename = lambda: obj1.file.filename
+        obj2.file.getFilename = lambda: obj2.file.filename
+        diff = BinaryDiff.BinaryDiff(obj1, obj2, 'file')
+        self.assertTrue(IDifference.providedBy(diff))
+        self.assertFalse(diff.same)
+        # The script tag should be escaped.
+        self.assertNotIn("<script", diff.inline_diff())
+        self.assertIn("&gt;", diff.inline_diff())

--- a/Products/CMFDiffTool/tests/test_filelistdiff.py
+++ b/Products/CMFDiffTool/tests/test_filelistdiff.py
@@ -56,6 +56,17 @@ class AsTextDiffTestCase(unittest.TestCase):
             [],
             False,
         )
+        self._test_diff_files(
+            [
+                ('<script>alert("Hacker data 1")</script>', u'filename1'),
+                ('<script>alert("Hacker data 2")</script>', u'filename2'),
+            ],
+            [
+                ('data1', u'<script>alert("Hacker data")</script>.txt'),
+                ('<script>alert("Hacker data 2")</script>', u'filename2'),
+            ],
+            False,
+        )
         self._test_diff_files(None, None, True)
         self._test_diff_files([], [], True)
         self._test_diff_files([], None, True)
@@ -65,4 +76,8 @@ class AsTextDiffTestCase(unittest.TestCase):
             DummyType(files1), DummyType(files2), 'files')
         self.assertTrue(IDifference.providedBy(diff))
         self.assertEqual(diff.same, same)
-        self.assertNotEqual(bool(diff.inline_diff()), same)
+        inline = diff.inline_diff()
+        self.assertNotEqual(bool(inline), same)
+        if inline:
+            # No hacker can catch us unawares.
+            self.assertNotIn("<script", inline)

--- a/Products/CMFDiffTool/tests/test_richtextdiff.py
+++ b/Products/CMFDiffTool/tests/test_richtextdiff.py
@@ -33,6 +33,14 @@ class RichTextDiffTestCase(unittest.TestCase):
         self.assertEqual(diff.same, True)
         self.assertEqual(inline_diff, u'foo ')
 
+    def test_inline_diff_same_hacker(self):
+        value = RichTextValue(u'<script>alert("Hacker value")</script>')
+        diff = CMFDTHtmlDiff(DummyType(value), DummyType(value), 'body')
+        inline_diff = diff.inline_diff()
+        # The script tag should be escaped.
+        self.assertNotIn("<script", inline_diff)
+        self.assertIn("&gt;", inline_diff)
+
     def test_inline_diff_different(self):
         old_value = RichTextValue(u'foo')
         new_value = RichTextValue(u'foo bar')
@@ -44,3 +52,20 @@ class RichTextDiffTestCase(unittest.TestCase):
         self.assertTrue(IDifference.providedBy(diff))
         self.assertEqual(diff.same, False)
         self.assertEqual(inline_diff, u'foo <span class="insert">bar </span> ')
+
+    def test_inline_diff_different_hacker(self):
+        old_value = RichTextValue(u'clean')
+        new_value = RichTextValue(u'<script>alert("Hacker value")</script>')
+        diff = CMFDTHtmlDiff(DummyType(old_value), DummyType(new_value), 'body')
+        inline_diff = diff.inline_diff()
+        # The script tag should be escaped.
+        self.assertNotIn("<script", inline_diff)
+        self.assertIn("&gt;", inline_diff)
+
+        old_value = RichTextValue(u'<script>alert("Hacker value")</script>')
+        new_value = RichTextValue(u'clean')
+        diff = CMFDTHtmlDiff(DummyType(old_value), DummyType(new_value), 'body')
+        inline_diff = diff.inline_diff()
+        # The script tag should be escaped.
+        self.assertNotIn("<script", inline_diff)
+        self.assertIn("&gt;", inline_diff)

--- a/Products/CMFDiffTool/utils.py
+++ b/Products/CMFDiffTool/utils.py
@@ -3,6 +3,12 @@
 import six
 
 
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
+
+
 def safe_unicode(value):
     if isinstance(value, six.text_type):
         return value
@@ -15,3 +21,20 @@ def safe_unicode(value):
 
 def safe_utf8(value):
     return safe_unicode(value).encode('utf-8')
+
+
+# In both Python 2 and 3, the escape function cannot handle a non string-like value,
+# for example an integer.  Seems good to always return a string-like value though.
+# But should that be bytes or string or unicode?
+if six.PY2:
+    # We use this in places where the result gets inserted in a string/bytes,
+    # so we should use a string (utf-8) here.
+    def html_encode(value):
+        value = safe_utf8(value)
+        return escape(value, 1)
+else:
+    # In Python 3 this gets inserted in a string/text,
+    # and escape cannot handle a bytes value.
+    def html_encode(value):
+        value = safe_unicode(value)
+        return escape(value, 1)

--- a/news/39.bugfix
+++ b/news/39.bugfix
@@ -1,0 +1,3 @@
+Added XSS fix from PloneHotfix20210518.
+See `vulnerability <https://plone.org/security/hotfix/20210518/xss-vulnerability-in-cmfdifftool>`_.
+[maurits]


### PR DESCRIPTION
Note that we only need to fix the inline_diff.
The html_diff is generated by difflib, which seems to do this just fine.

This is from PloneHotfix20210518.
Fixes issue #39.